### PR TITLE
Use International Mile for UnitLength operations

### DIFF
--- a/Sources/Foundation/Unit.swift
+++ b/Sources/Foundation/Unit.swift
@@ -1253,7 +1253,7 @@ public final class UnitLength : Dimension {
         static let inches               = 0.0254
         static let feet                 = 0.3048
         static let yards                = 0.9144
-        static let miles                = 1609.34
+        static let miles                = 1609.344
         static let scandinavianMiles    = 10000.0
         static let lightyears           = 9.461e+15
         static let nauticalMiles        = 1852.0


### PR DESCRIPTION
I made this PR based on some conversation in [this](https://stackoverflow.com/questions/49373300) SO post. This patch changes the Coefficient for the mile to `1609.344`, to be in-line with the official definition of the "international mile".


From the NIST's _[Conversion Factor's for General Use](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication1038.pdf)_ handbook:
![image](https://user-images.githubusercontent.com/3804041/128943657-7e86d806-204a-411f-b2ae-50ba2f581cf8.png)


The existing Coefficient leads to an incorrect result. This can be seen by trying to convert 1 mile to feet (1 mile should be 5280 feet):
`1 * 1609.34 / 0.3048 = 5279.9868766404199475065616797900262467191601049868766404199475065...`
Using the standard `1609.344` instead gives `5280`.


The Coefficients for inches, feet, and yards are all correct.